### PR TITLE
DM-29897: Implement ofc refactor in MTAOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,25 +59,17 @@ pipeline {
             }
         }
 
-        stage ('Cloning Repos') {
-            steps {
-                dir(env.WORKSPACE + '/phosim_utils') {
-                    git branch: 'master', url: 'https://github.com/lsst-dm/phosim_utils.git'
-                }
-                dir(env.WORKSPACE + '/ts_wep') {
-                    git branch: "${BRANCH}", url: 'https://github.com/lsst-ts/ts_wep.git'
-                }
-                dir(env.WORKSPACE + '/ts_ofc') {
-                    git branch: "${BRANCH}", url: 'https://github.com/lsst-ts/ts_ofc.git'
-                }
-            }
-        }
-
         stage ('Building the Dependencies') {
             steps {
                 withEnv(["HOME=${env.WORKSPACE}"]) {
                     sh """
                         source ${env.SAL_SETUP_FILE}
+
+                        cd ${env.SAL_USERS_HOME}
+
+                        git clone --branch master --depth 1 --single-branch https://github.com/lsst-dm/phosim_utils.git
+                        git clone --branch ${BRANCH} --depth 1 --single-branch https://github.com/lsst-ts/ts_wep.git
+                        git clone --branch ${BRANCH} --depth 1 --single-branch https://github.com/lsst-ts/ts_ofc.git
 
                         cd phosim_utils/
                         setup -k -r . -t ${env.STACK_VERSION}
@@ -132,6 +124,8 @@ pipeline {
                     sh """
                         source ${env.SAL_SETUP_FILE}
 
+                        cd ${env.SAL_USERS_HOME}
+
                         cd phosim_utils/
                         setup -k -r . -t ${env.STACK_VERSION}
 
@@ -141,9 +135,9 @@ pipeline {
                         cd ../ts_ofc/
                         setup -k -r .
 
-                        cd ../
+                        cd ${HOME}
                         setup -k -r .
-                        pytest --cov-report html --cov=${env.MODULE_NAME} --junitxml=${env.XML_REPORT} tests/
+                        pytest --cov-report html --cov=${env.MODULE_NAME} --junitxml=${env.XML_REPORT}
                     """
                 }
             }
@@ -155,6 +149,8 @@ pipeline {
                     sh """
                         source ${env.SAL_SETUP_FILE}
 
+                        cd ${env.SAL_USERS_HOME}
+
                         cd phosim_utils/
                         setup -k -r . -t ${env.STACK_VERSION}
 
@@ -164,7 +160,7 @@ pipeline {
                         cd ../ts_ofc/
                         setup -k -r .
 
-                        cd ../
+                        cd ${HOME}
                         setup -k -r .
 
                         package-docs build

--- a/doc/user-guide/user-guide.rst
+++ b/doc/user-guide/user-guide.rst
@@ -163,6 +163,12 @@ To use this command the user would do:
 
   await mtaosCsc.cmd_addAberration.set_start(wf=wf)
 
+  await mtaosCsc.cmd_issueCorrection.start()
+
+Note that the ``addAberration`` command itself does not send the corrections.
+It only computes and store them in the model.
+A user can send the corrections by sending a ``issueCorrection`` command, and ignore them with a ``resetCorrection``.
+
 .. ofc: Need to provide a link for the ofc in the future.
 
 .. note::

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -2,6 +2,21 @@
 Version History
 ===============
 
+v0.6.0
+------
+
+* In Jenkinsfile, run pytest in the entire package instead of only the `tests/` folder, to capture pep8 and black violations in the entire repo.
+* Refactor module names to the current telescope and site standards (lower_camel_case).
+* Refactor additional parts of the code to be compliant with the current style guide.
+* Implement new version of OFC.
+* In CSC:
+  * Refactor log-to-file interface.
+  * In `addAberration` command:
+    * Stop issuing corrections. Users need to send a `issueAberration` for the aberrations to be applied.
+    * Implement `config` feature, to allow users to customize ofc behavior.
+    * Add some unit tests for `addAberration` config feature.
+* Update tests/Sconscript to allow running scons with licensed version of OpenSplice.
+
 v0.5.6
 ------
 

--- a/python/lsst/ts/MTAOS/__init__.py
+++ b/python/lsst/ts/MTAOS/__init__.py
@@ -27,9 +27,9 @@ try:
 except ImportError:
     __version__ = "?"
 
-from .CollOfListOfWfErr import *
-from .Config import *
+from .wavefront_collection import *
+from .config import *
 from .config_schema import *
-from .Model import *
-from .Utility import *
-from .MtaosCsc import *
+from .model import *
+from .utility import *
+from .mtaos import *

--- a/python/lsst/ts/MTAOS/config.py
+++ b/python/lsst/ts/MTAOS/config.py
@@ -25,7 +25,7 @@ from collections import namedtuple
 import warnings
 import yaml
 
-from . import Utility
+from . import utility
 
 
 class Config(object):
@@ -49,22 +49,22 @@ class Config(object):
 
         Returns
         -------
-        enum 'CamType' in lsst.ts.wep.Utility
+        enum 'CamType' in lsst.ts.wep.utility
             Camera type.
         """
 
-        return Utility.getCamType(self.configObj.camera)
+        return utility.getCamType(self.configObj.camera)
 
     def getInstName(self):
         """Get the enum of instrument name in the configuration.
 
         Returns
         -------
-        enum 'InstName' in lsst.ts.ofc.Utility
+        enum 'InstName' in lsst.ts.ofc.utility
             Instrument name.
         """
 
-        return Utility.getInstName(self.configObj.instrument)
+        return self.configObj.instrument
 
     def getIsrDir(self):
         """Get the ISR directory.
@@ -79,7 +79,7 @@ class Config(object):
             ISR directory.
         """
 
-        isrDir = Utility.getIsrDirPath()
+        isrDir = utility.getIsrDirPath()
         if isrDir is None:
             isrDir = self.configObj.defaultIsrDir
             warnings.warn(
@@ -106,7 +106,7 @@ class Config(object):
             relativePath = self.configObj.defaultSkyFilePath
         except AttributeError:
             return None
-        return Utility.getModulePath().joinpath(relativePath)
+        return utility.getModulePath().joinpath(relativePath)
 
     def getState0DofFile(self):
         """Get the state 0 DoF filename.
@@ -122,4 +122,4 @@ class Config(object):
             relativePath = self.configObj.state0DofFilePath
         except AttributeError:
             return None
-        return Utility.getModulePath().joinpath(relativePath)
+        return utility.getModulePath().joinpath(relativePath)

--- a/python/lsst/ts/MTAOS/config_schema.py
+++ b/python/lsst/ts/MTAOS/config_schema.py
@@ -46,20 +46,6 @@ properties:
     enum: [lsst, comcam, sh, cmos]
     default: comcam
 
-  defaultIsrDir:
-    description: >
-      Default instrument signature removal (ISR) directory.
-      This setting will be override by the 'ISRDIRPATH' path variable.
-    type: string
-    default: /home/lsst/input
-
-  defaultSkyFilePath:
-    description: >
-      Default sky file path relative to the root of module.
-      This is for the test only.
-    type: string
-    default: tests/testData/phosimOutput/realComCam/skyComCamInfo.txt
-
 required:
   - camera
   - instrument

--- a/python/lsst/ts/MTAOS/utility.py
+++ b/python/lsst/ts/MTAOS/utility.py
@@ -28,7 +28,6 @@ __all__ = [
     "getLogDir",
     "getIsrDirPath",
     "getCamType",
-    "getInstName",
     "getCscName",
     "addRotFileHandler",
     "timeit",
@@ -45,7 +44,6 @@ from pathlib import Path
 from lsst.utils import getPackageDir
 
 from lsst.ts.wep.Utility import CamType
-from lsst.ts.ofc.Utility import InstName
 
 
 class WEPWarning(Enum):
@@ -147,37 +145,6 @@ def getCamType(camera):
         return CamType.ComCam
     else:
         raise ValueError("The camera (%s) is not supported." % camera)
-
-
-def getInstName(instName):
-    """Get the enum of instrument name.
-
-    Parameters
-    ----------
-    instName : str
-        Instrument name.
-
-    Returns
-    -------
-    enum 'InstName' in lsst.ts.ofc.Utility
-        Instrument name.
-
-    Raises
-    ------
-    ValueError
-        This instrument is not supported.
-    """
-
-    if instName == "lsst":
-        return InstName.LSST
-    elif instName == "comcam":
-        return InstName.COMCAM
-    elif instName == "sh":
-        return InstName.SH
-    elif instName == "cmos":
-        return InstName.CMOS
-    else:
-        raise ValueError("This instrument (%s) is not supported." % instName)
 
 
 def getCscName():

--- a/python/lsst/ts/MTAOS/wavefront_collection.py
+++ b/python/lsst/ts/MTAOS/wavefront_collection.py
@@ -19,13 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["CollOfListOfWfErr"]
+__all__ = ["WavefrontCollection"]
 
 import numpy as np
 from collections import deque
 
 
-class CollOfListOfWfErr(object):
+class WavefrontCollection(object):
     def __init__(self, maxLeng):
         """Collection of list of wavefront sensor data.
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -5,7 +5,7 @@ from lsst.sconsUtils import env, scripts
 
 scripts.BasicSConscript.tests(pyList=[])
 
-for name in ("OSPL_URI", "OPENSPLICE_LOC"):
+for name in ("LSST_DDS_QOS", "OSPL_HOME", "OSPL_URI", "ADLINK_LICENSE"):
     val = os.environ.get(name)
     if val is not None:
         env.AppendENVPath(name, val)

--- a/tests/test_configByFile.py
+++ b/tests/test_configByFile.py
@@ -23,7 +23,6 @@ import os
 import unittest
 
 from lsst.ts.wep.Utility import CamType
-from lsst.ts.ofc.Utility import InstName
 
 from lsst.ts import MTAOS
 
@@ -53,7 +52,7 @@ class TestConfigByFile(unittest.TestCase):
     def testGetInstName(self):
 
         instName = self.config.getInstName()
-        self.assertEqual(instName, InstName.COMCAM)
+        self.assertEqual(instName, "comcam")
 
     def testGetIsrDirWithEnvPath(self):
 

--- a/tests/test_configByObj.py
+++ b/tests/test_configByObj.py
@@ -23,7 +23,6 @@ import os
 import unittest
 
 from lsst.ts.wep.Utility import CamType
-from lsst.ts.ofc.Utility import InstName
 
 from lsst.ts import MTAOS
 
@@ -70,7 +69,7 @@ class TestConfigByObj(unittest.TestCase):
     def testGetInstName(self):
 
         instName = self.configObj.getInstName()
-        self.assertEqual(instName, InstName.COMCAM)
+        self.assertEqual(instName, "comcam")
 
     def testGetIsrDirWithEnvPath(self):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,9 +26,8 @@ import unittest
 import numpy as np
 import yaml
 
-from lsst.ts.ofc.ctrlIntf.OFCCalculationOfComCam import OFCCalculationOfComCam
-from lsst.ts.ofc.ctrlIntf.M1M3Correction import M1M3Correction
-from lsst.ts.ofc.ctrlIntf.M2Correction import M2Correction
+from lsst.ts.ofc import OFC, OFCData
+from lsst.ts.ofc.utils import CorrectionType
 
 from lsst.ts import MTAOS
 
@@ -48,14 +47,19 @@ class TestModel(unittest.TestCase):
         settingFilePath = MTAOS.getModulePath().joinpath(
             "tests", "testData", "default.yaml"
         )
+
+        ofc_data = OFCData("comcam")
+
         config = MTAOS.Config(str(settingFilePath))
-        state0Dof = yaml.safe_load(
+        dof_state0 = yaml.safe_load(
             MTAOS.getModulePath()
             .joinpath("tests", "testData", "state0inDof.yaml")
             .open()
             .read()
         )
-        cls.model = MTAOS.Model(config, state0Dof)
+        ofc_data.dof_state0 = dof_state0
+
+        cls.model = MTAOS.Model(config, ofc_data)
 
     def setUp(self):
         os.environ["ISRDIRPATH"] = self.isrDir.as_posix()
@@ -67,8 +71,8 @@ class TestModel(unittest.TestCase):
 
     def tearDown(self):
 
-        self.model.resetFWHMSensorData()
-        self.model.resetWavefrontCorrection()
+        self.model.reset_fwhm_data()
+        self.model.reset_wfe_correction()
 
         shutil.rmtree(self.dataDir)
         try:
@@ -76,71 +80,69 @@ class TestModel(unittest.TestCase):
         except KeyError:
             pass
 
-    def testInitOfModelMTAOS(self):
+    def test_init(self):
 
-        ofc = self.model.ofc
-        self.assertTrue(isinstance(ofc, OFCCalculationOfComCam))
+        self.assertTrue(isinstance(self.model.ofc, OFC))
+        self.assertEqual(self.model.ofc.ofc_data.name, "comcam")
 
-    def testGetListOfWavefrontError(self):
+    def test_get_wfe(self):
 
-        self.assertEqual(self.model.getListOfWavefrontError(), [])
+        self.assertEqual(self.model.get_wfe(), [])
 
-    def testGetListOfWavefrontErrorRej(self):
+    def test_get_rejected_wfe(self):
 
-        self.assertEqual(self.model.getListOfWavefrontErrorRej(), [])
+        self.assertEqual(self.model.get_rejected_wfe(), [])
 
-    def testGetListOfFWHMSensorData(self):
+    def test_get_fwhm_sensors(self):
 
-        self.assertEqual(self.model.getListOfFWHMSensorData(), [])
+        self.assertEqual(self.model.get_fwhm_sensors(), [])
 
-    def testSetFWHMSensorData(self):
+        self.model.set_fwhm_data(5, np.zeros(2))
+        self.assertEqual(len(self.model.get_fwhm_sensors()), 1)
+        self.assertEqual(self.model.get_fwhm_sensors()[0], 5)
 
-        self.model.setFWHMSensorData(1, np.zeros(2))
+    def test_set_fwhm_data(self):
 
-        listOfFWHMSensorData = self.model.getListOfFWHMSensorData()
-        self.assertEqual(len(listOfFWHMSensorData), 1)
+        self.model.set_fwhm_data(1, np.zeros(2))
 
-        self.model.setFWHMSensorData(2, np.zeros(2))
-        self.assertEqual(len(listOfFWHMSensorData), 2)
+        fwhm_data = self.model.get_fwhm_data()
+        self.assertEqual(len(fwhm_data), 1)
 
-    def testSetFWHMSensorDataRepeatSensorId(self):
+        self.model.set_fwhm_data(2, np.zeros(3))
+        self.model.set_fwhm_data(3, np.zeros(4))
 
-        self.model.setFWHMSensorData(1, np.zeros(2))
+        fwhm_data = self.model.get_fwhm_data()
+        self.assertEqual(len(fwhm_data), 3)
 
-        newFwhmValues = np.array([1, 2, 3])
-        self.model.setFWHMSensorData(1, newFwhmValues)
+    def test_set_fwhm_data_repeat_sensor(self):
 
-        listOfFWHMSensorData = self.model.getListOfFWHMSensorData()
-        self.assertEqual(len(listOfFWHMSensorData), 1)
+        self.model.set_fwhm_data(1, np.zeros(2))
 
-        fwhmValuesInList = listOfFWHMSensorData[0].getFwhmValues()
-        self.assertTrue((fwhmValuesInList == newFwhmValues).all())
+        new_fwhm_values = np.array([1, 2, 3])
+        self.model.set_fwhm_data(1, new_fwhm_values)
 
-    def testResetFWHMSensorData(self):
+        fwhm_data = self.model.get_fwhm_data()
 
-        self.model.setFWHMSensorData(1, np.zeros(2))
-        self.model.resetFWHMSensorData()
+        self.assertEqual(len(fwhm_data), 1)
 
-        listOfFWHMSensorData = self.model.getListOfFWHMSensorData()
-        self.assertEqual(listOfFWHMSensorData, [])
+        fwhm_values_in_list = fwhm_data[0]
+        self.assertTrue(np.all(fwhm_values_in_list == new_fwhm_values))
 
-    def testGetDofAggr(self):
+    def test_reset_fwhm_data(self):
 
-        dofAggr = self._getDofAggr()
-        self.assertEqual(len(dofAggr), 50)
+        self.model.set_fwhm_data(1, np.zeros(2))
+        self.model.reset_fwhm_data()
 
-    def _getDofAggr(self):
+        fwhm_data = self.model.get_fwhm_data()
+        self.assertEqual(len(fwhm_data), 0)
 
-        return self.model.getDofAggr()
+    def test_get_aggr_dof(self):
 
-    def testGetDofVisit(self):
+        self.assertEqual(len(self.model.get_aggr_dof()), 50)
 
-        dofVisit = self._getDofVisit()
-        self.assertEqual(len(dofVisit), 50)
+    def test_get_lv_dof(self):
 
-    def _getDofVisit(self):
-
-        return self.model.getDofVisit()
+        self.assertEqual(len(self.model.get_lv_dof()), 50)
 
     def test_add_correction(self):
 
@@ -149,7 +151,7 @@ class TestModel(unittest.TestCase):
         # Passing in zeros for wavefront_errors should return 0 in correction
         self.model.add_correction(wavefront_erros)
 
-        x, y, z, u, v, w = self.model.getM2HexCorr()
+        x, y, z, u, v, w = self.model.m2_hexapod_correction()
 
         self.assertEqual(x, 0)
         self.assertEqual(y, 0)
@@ -158,7 +160,7 @@ class TestModel(unittest.TestCase):
         self.assertEqual(v, 0)
         self.assertEqual(w, 0)
 
-        x, y, z, u, v, w = self.model.getCamHexCorr()
+        x, y, z, u, v, w = self.model.cam_hexapod_correction()
         self.assertEqual(x, 0)
         self.assertEqual(y, 0)
         self.assertEqual(z, 0)
@@ -166,10 +168,10 @@ class TestModel(unittest.TestCase):
         self.assertEqual(v, 0)
         self.assertEqual(w, 0)
 
-        actCorr = self.model.getM1M3ActCorr()
+        actCorr = self.model.m1m3_correction()
         self.assertListEqual(actCorr.tolist(), np.zeros_like(actCorr).tolist())
 
-        actCorr = self.model.getM2ActCorr()
+        actCorr = self.model.m2_correction()
         self.assertListEqual(actCorr.tolist(), np.zeros_like(actCorr).tolist())
 
         # Give 0.1 um of focus correction. All values must be close to zero
@@ -178,7 +180,7 @@ class TestModel(unittest.TestCase):
         wavefront_erros[0] = 0.1
         self.model.add_correction(wavefront_erros)
 
-        x, y, z_m2hex, u, v, w = self.model.getM2HexCorr()
+        x, y, z_m2hex, u, v, w = self.model.m2_hexapod_correction()
 
         self.assertAlmostEqual(x, 0, 3)
         self.assertAlmostEqual(y, 0, 3)
@@ -186,7 +188,7 @@ class TestModel(unittest.TestCase):
         self.assertAlmostEqual(v, 0, 3)
         self.assertAlmostEqual(w, 0, 3)
 
-        x, y, z_camhex, u, v, w = self.model.getCamHexCorr()
+        x, y, z_camhex, u, v, w = self.model.cam_hexapod_correction()
 
         self.assertAlmostEqual(x, 0, 3)
         self.assertAlmostEqual(y, 0, 3)
@@ -197,21 +199,24 @@ class TestModel(unittest.TestCase):
         # Expected total hexapod offset
         self.assertAlmostEqual(z_m2hex + z_camhex, 4.16211, 3)
 
-        actCorr = self.model.getM1M3ActCorr()
+        actCorr = self.model.m1m3_correction()
         self.assertTrue(
             np.allclose(actCorr, np.zeros_like(actCorr), rtol=0.1, atol=0.1),
             f"{actCorr} not almost close to 0.",
         )
 
-        actCorr = self.model.getM2ActCorr()
+        actCorr = self.model.m2_correction()
         self.assertTrue(
             np.allclose(actCorr, np.zeros_like(actCorr), rtol=0.1, atol=0.1),
             f"{actCorr} not almost close to 0.",
         )
 
-    def testGetM2HexCorr(self):
+    def test_m2_hexapod_correction(self):
 
-        x, y, z, u, v, w = self.model.getM2HexCorr()
+        x, y, z, u, v, w = self.model.m2_hexapod_correction()
+        self.assertEqual(
+            self.model.m2_hexapod_correction.correction_type, CorrectionType.POSITION
+        )
         self.assertEqual(x, 0)
         self.assertEqual(y, 0)
         self.assertEqual(z, 0)
@@ -219,9 +224,12 @@ class TestModel(unittest.TestCase):
         self.assertEqual(v, 0)
         self.assertEqual(w, 0)
 
-    def testGetCamHexCorr(self):
+    def test_cam_hexapod_correction(self):
 
-        x, y, z, u, v, w = self.model.getCamHexCorr()
+        self.assertEqual(
+            self.model.cam_hexapod_correction.correction_type, CorrectionType.POSITION
+        )
+        x, y, z, u, v, w = self.model.cam_hexapod_correction()
         self.assertEqual(x, 0)
         self.assertEqual(y, 0)
         self.assertEqual(z, 0)
@@ -229,34 +237,32 @@ class TestModel(unittest.TestCase):
         self.assertEqual(v, 0)
         self.assertEqual(w, 0)
 
-    def testGetM1M3ActCorr(self):
+    def test_m1m3_correction(self):
 
-        actCorr = self.model.getM1M3ActCorr()
-        self.assertEqual(len(actCorr), M1M3Correction.NUM_OF_ACT)
+        self.assertEqual(
+            self.model.m1m3_correction.correction_type, CorrectionType.FORCE
+        )
+        self.assertEqual(len(self.model.m1m3_correction()), 156)
 
-    def testGetM2ActCorr(self):
+    def test_m2_correction(self):
 
-        actCorr = self.model.getM2ActCorr()
-        self.assertEqual(len(actCorr), M2Correction.NUM_OF_ACT)
+        self.assertEqual(self.model.m2_correction.correction_type, CorrectionType.FORCE)
+        self.assertEqual(len(self.model.m2_correction()), 72)
 
-    def testResetWavefrontCorrection(self):
+    def test_reset_wfe_correction(self):
 
         data = [1, 2, 3]
         self.model.wavefront_errors.append(data)
         self.model.rejected_wavefront_errors.append(data)
 
-        self.model.resetWavefrontCorrection()
+        self.model.reset_wfe_correction()
 
-        self._checkWfsErrAndWfsErrRejClear()
+        self.assertEqual(self.model.get_wfe(), [])
+        self.assertEqual(self.model.get_rejected_wfe(), [])
 
-    def _checkWfsErrAndWfsErrRejClear(self):
+    def test_reject_unreasonable_wfe(self):
 
-        self.assertEqual(self.model.getListOfWavefrontError(), [])
-        self.assertEqual(self.model.getListOfWavefrontErrorRej(), [])
-
-    def testRejWavefrontErrorUnreasonable(self):
-
-        self.assertEqual(self.model.rejWavefrontErrorUnreasonable([]), [])
+        self.assertEqual(self.model.reject_unreasonable_wfe([]), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_mtaosCsc.py
+++ b/tests/test_mtaosCsc.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
+import yaml
 import unittest
 
 import numpy as np
@@ -31,13 +32,12 @@ from lsst.ts import MTAOS
 
 # standard command timeout (sec)
 STD_TIMEOUT = 60
+SHORT_TIMEOUT = 5
 
 
 class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
     def basic_make_csc(self, initial_state, config_dir, simulation_mode):
-        return MTAOS.MtaosCsc(
-            config_dir=config_dir, simulation_mode=simulation_mode, log_to_file=True
-        )
+        return MTAOS.MtaosCsc(config_dir=config_dir, simulation_mode=simulation_mode)
 
     def setUp(self):
 
@@ -67,7 +67,7 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         return self.remote
 
     async def testBinScript(self):
-        cmdline_args = ["--logToFile", "--debugLevel", "20"]
+        cmdline_args = ["--log-to-file", "--log-level", "20"]
         await self.check_bin_script(
             "MTAOS", 0, "run_mtaos.py", cmdline_args=cmdline_args
         )
@@ -101,7 +101,7 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             await remote.cmd_resetCorrection.set_start(timeout=STD_TIMEOUT)
 
             dof = await remote.evt_degreeOfFreedom.next(
-                flush=False, timeout=STD_TIMEOUT
+                flush=False, timeout=SHORT_TIMEOUT
             )
             dofAggr = dof.aggregatedDoF
             dofVisit = dof.visitDoF
@@ -154,14 +154,16 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         async with self.make_csc(
             initial_state=salobj.State.STANDBY, config_dir=None, simulation_mode=0
         ):
+
             await salobj.set_summary_state(self.remote, salobj.State.ENABLED)
 
             remote = self._getRemote()
+
             with self.assertRaises(salobj.AckError):
                 await remote.cmd_issueCorrection.set_start(timeout=10.0)
 
             dof = await remote.evt_rejectedDegreeOfFreedom.next(
-                flush=False, timeout=STD_TIMEOUT
+                flush=False, timeout=SHORT_TIMEOUT
             )
             dofAggr = dof.aggregatedDoF
             dofVisit = dof.visitDoF
@@ -173,13 +175,94 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             await self.assert_next_sample(
                 remote.evt_rejectedM2HexapodCorrection,
                 flush=False,
-                timeout=STD_TIMEOUT,
+                timeout=SHORT_TIMEOUT,
                 x=0,
                 y=0,
                 z=0,
                 u=0,
                 v=0,
                 w=0,
+            )
+
+    async def test_addAberration(self):
+        async with self.make_csc(
+            initial_state=salobj.State.STANDBY, config_dir=None, simulation_mode=0
+        ):
+
+            await salobj.set_summary_state(self.remote, salobj.State.ENABLED)
+
+            remote = self._getRemote()
+
+            # Flush all events before command is sent
+            remote.evt_degreeOfFreedom.flush()
+            remote.evt_m2HexapodCorrection.flush()
+            remote.evt_cameraHexapodCorrection.flush()
+            remote.evt_m1m3Correction.flush()
+            remote.evt_m2Correction.flush()
+
+            await remote.cmd_addAberration.set_start(
+                wf=np.zeros(19), timeout=STD_TIMEOUT
+            )
+
+            await self.assert_next_sample(
+                remote.evt_degreeOfFreedom,
+                flush=False,
+                timeout=SHORT_TIMEOUT,
+            )
+
+            await self.assert_next_sample(
+                remote.evt_m2HexapodCorrection, flush=False, timeout=SHORT_TIMEOUT
+            )
+            await self.assert_next_sample(
+                remote.evt_cameraHexapodCorrection, flush=False, timeout=SHORT_TIMEOUT
+            )
+            await self.assert_next_sample(
+                remote.evt_m1m3Correction, flush=False, timeout=SHORT_TIMEOUT
+            )
+            await self.assert_next_sample(
+                remote.evt_m2Correction, flush=False, timeout=SHORT_TIMEOUT
+            )
+
+    async def test_addAberration_with_config(self):
+        async with self.make_csc(
+            initial_state=salobj.State.STANDBY, config_dir=None, simulation_mode=0
+        ):
+
+            await salobj.set_summary_state(self.remote, salobj.State.ENABLED)
+
+            remote = self._getRemote()
+
+            # Flush all events before command is sent
+            remote.evt_degreeOfFreedom.flush()
+            remote.evt_m2HexapodCorrection.flush()
+            remote.evt_cameraHexapodCorrection.flush()
+            remote.evt_m1m3Correction.flush()
+            remote.evt_m2Correction.flush()
+
+            # set control algorithm
+            config = dict(xref="x0")
+
+            await remote.cmd_addAberration.set_start(
+                wf=np.zeros(19), config=yaml.safe_dump(config), timeout=STD_TIMEOUT
+            )
+
+            await self.assert_next_sample(
+                remote.evt_degreeOfFreedom,
+                flush=False,
+                timeout=SHORT_TIMEOUT,
+            )
+
+            await self.assert_next_sample(
+                remote.evt_m2HexapodCorrection, flush=False, timeout=SHORT_TIMEOUT
+            )
+            await self.assert_next_sample(
+                remote.evt_cameraHexapodCorrection, flush=False, timeout=SHORT_TIMEOUT
+            )
+            await self.assert_next_sample(
+                remote.evt_m1m3Correction, flush=False, timeout=SHORT_TIMEOUT
+            )
+            await self.assert_next_sample(
+                remote.evt_m2Correction, flush=False, timeout=SHORT_TIMEOUT
             )
 
     @unittest.skip("Skip until commands implementation.")

--- a/tests/test_mtaosCscWithSimulators.py
+++ b/tests/test_mtaosCscWithSimulators.py
@@ -32,9 +32,7 @@ STD_TIMEOUT = 60
 
 class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
     def basic_make_csc(self, initial_state, config_dir, simulation_mode):
-        return MTAOS.MtaosCsc(
-            config_dir=config_dir, simulation_mode=simulation_mode, log_to_file=True
-        )
+        return MTAOS.MtaosCsc(config_dir=config_dir, simulation_mode=simulation_mode)
 
     def setUp(self):
 
@@ -49,39 +47,13 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
         self.m1m3_corrections = []
         self.m2_corrections = []
 
-        # Simulated CSC tasks
-        self.taskM2Hex = None
-        self.taskCamHex = None
-        self.taskM1M3 = None
-        self.taskM2 = None
-
     def tearDown(self):
 
         logFile = Path(MTAOS.getLogDir()).joinpath("MTAOS.log")
         if logFile.exists():
             logFile.unlink()
 
-    @unittest.skip("Skip until commands implementation.")
-    async def testIssueCorrection(self):
-        async with self.make_csc(
-            initial_state=salobj.State.STANDBY, config_dir=None, simulation_mode=1
-        ):
-
-            await self._simulateCSCs()
-
-            await self._startCsc()
-
-            # Set the timeout > 20 seconds for the long calculation time
-            remote = self._getRemote()
-            await remote.cmd_runWEP.set_start()
-
-            await remote.cmd_runOFC.set_start()
-
-            await remote.cmd_issueCorrection.set_start(timeout=10.0, value=True)
-
-            await self._cancelCSCs()
-
-    async def test_addAberration(self):
+    async def test_addAberration_issueCorrection(self):
         async with self.make_csc(
             initial_state=salobj.State.STANDBY, config_dir=None, simulation_mode=0
         ):
@@ -92,7 +64,18 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             # Set the timeout > 20 seconds for the long calculation time
             remote = self._getRemote()
 
-            await remote.cmd_addAberration.set_start(wf=np.zeros(19), timeout=10.0)
+            # User the addAberration to have something to issue
+            wfe = np.zeros(19)
+            await remote.cmd_addAberration.set_start(wf=wfe, timeout=STD_TIMEOUT)
+
+            # Add aberration does not send the corrections, we need to send
+            # run issueCorrections
+            self.assertEqual(len(self.m2_hex_corrections), 0)
+            self.assertEqual(len(self.cam_hex_corrections), 0)
+            self.assertEqual(len(self.m1m3_corrections), 0)
+            self.assertEqual(len(self.m2_corrections), 0)
+
+            await remote.cmd_issueCorrection.start(timeout=STD_TIMEOUT)
 
             # There must be 1 correction for each component
             self.assertEqual(len(self.m2_hex_corrections), 1)
@@ -126,8 +109,10 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
             wf = np.random.rand(19) * 0.1
 
+            await remote.cmd_addAberration.set_start(wf=wf, timeout=10.0)
+
             with self.assertRaises(salobj.AckError):
-                await remote.cmd_addAberration.set_start(wf=wf, timeout=10.0)
+                await remote.cmd_issueCorrection.start(timeout=STD_TIMEOUT)
 
             # There must be 3 corrections for each component except for m1m3
             # which got rejected. The corrections are 1 from the previous test,
@@ -139,7 +124,8 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
             self.assertEqual(len(self.m1m3_corrections), 1)
             self.assertEqual(len(self.m2_corrections), 3)
 
-            # Check values.
+            # Check values. The last 2 corrections should have same values with
+            # different sign.
             for axis in "xyzuvw":
                 self.assertEqual(
                     getattr(self.m2_hex_corrections[1], axis),
@@ -162,40 +148,40 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
     async def _simulateCSCs(self):
 
-        # Mock controller that uses callback functions defined below
-        # to handle the expected commands
-        self.taskM2Hex = asyncio.create_task(self._simulateM2Hex())
-        self.taskCamHex = asyncio.create_task(self._simulateCamHex())
-        self.taskM1M3 = asyncio.create_task(self._simulateM1M3())
-        self.taskM2 = asyncio.create_task(self._simulateM2())
-
-    async def _simulateM2Hex(self):
-
         self.cscM2Hex = salobj.Controller(
-            "MTHexapod", index=MTAOS.Utility.MTHexapodIndex.M2.value
+            "MTHexapod", index=MTAOS.utility.MTHexapodIndex.M2.value
         )
-        self.cscM2Hex.cmd_move.callback = self.hexapod_move_callbck
-
-    def hexapod_move_callbck(self, data):
-
-        if data.MTHexapodID == MTAOS.Utility.MTHexapodIndex.M2.value:
-            self.m2_hex_corrections.append(data)
-        else:
-            self.cam_hex_corrections.append(data)
-
-    async def _simulateCamHex(self):
-
         self.cscCamHex = salobj.Controller(
-            "MTHexapod", index=MTAOS.Utility.MTHexapodIndex.Camera.value
+            "MTHexapod", index=MTAOS.utility.MTHexapodIndex.Camera.value
         )
-        self.cscCamHex.cmd_move.callback = self.hexapod_move_callbck
-
-    async def _simulateM1M3(self):
-
         self.cscM1M3 = salobj.Controller("MTM1M3")
+        self.cscM2 = salobj.Controller("MTM2")
+
+        await asyncio.gather(
+            *[
+                controller.start_task
+                for controller in {
+                    self.cscM2Hex,
+                    self.cscCamHex,
+                    self.cscM1M3,
+                    self.cscM2,
+                }
+            ]
+        )
+
+        self.cscM2Hex.cmd_move.callback = self.hexapod_move_callbck
+        self.cscCamHex.cmd_move.callback = self.hexapod_move_callbck
         self.cscM1M3.cmd_applyActiveOpticForces.callback = (
             self.m1m3_apply_forces_callbck
         )
+        self.cscM2.cmd_applyForces.callback = self.m2_apply_forces_callbck
+
+    def hexapod_move_callbck(self, data):
+
+        if data.MTHexapodID == MTAOS.utility.MTHexapodIndex.M2.value:
+            self.m2_hex_corrections.append(data)
+        else:
+            self.cam_hex_corrections.append(data)
 
     def m1m3_apply_forces_callbck(self, data):
 
@@ -204,11 +190,6 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
     def m1m3_apply_forces_fail_callbck(self, data):
 
         raise RuntimeError("This is a test.")
-
-    async def _simulateM2(self):
-
-        self.cscM2 = salobj.Controller("MTM2")
-        self.cscM2.cmd_applyForces.callback = self.m2_apply_forces_callbck
 
     def m2_apply_forces_callbck(self, data):
 
@@ -224,15 +205,12 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
 
     async def _cancelCSCs(self):
 
-        await self.cscM2Hex.close()
-        await self.cscCamHex.close()
-        await self.cscM1M3.close()
-        await self.cscM2.close()
-
-        self.taskM2Hex.cancel()
-        self.taskCamHex.cancel()
-        self.taskM1M3.cancel()
-        self.taskM2.cancel()
+        await asyncio.gather(
+            self.cscM2Hex.close(),
+            self.cscCamHex.close(),
+            self.cscM1M3.close(),
+            self.cscM2.close(),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -31,7 +31,6 @@ from pathlib import Path
 from logging.handlers import RotatingFileHandler
 
 from lsst.ts.wep.Utility import CamType
-from lsst.ts.ofc.Utility import InstName
 
 from lsst.ts import MTAOS
 
@@ -88,15 +87,6 @@ class TestUtility(unittest.TestCase):
         self.assertEqual(MTAOS.getCamType("comcam"), CamType.ComCam)
 
         self.assertRaises(ValueError, MTAOS.getCamType, "wrongType")
-
-    def testGetInst(self):
-
-        self.assertEqual(MTAOS.getInstName("lsst"), InstName.LSST)
-        self.assertEqual(MTAOS.getInstName("comcam"), InstName.COMCAM)
-        self.assertEqual(MTAOS.getInstName("sh"), InstName.SH)
-        self.assertEqual(MTAOS.getInstName("cmos"), InstName.CMOS)
-
-        self.assertRaises(ValueError, MTAOS.getInstName, "wrongName")
 
     def testGetCscName(self):
 

--- a/tests/test_wavefront_collection.py
+++ b/tests/test_wavefront_collection.py
@@ -24,30 +24,30 @@ import unittest
 
 from lsst.ts.wep.ctrlIntf.SensorWavefrontData import SensorWavefrontData
 
-from lsst.ts import MTAOS
+from lsst.ts.MTAOS import WavefrontCollection
 
 
-class TestCollOfListOfWfErr(unittest.TestCase):
+class TestWavefrontCollection(unittest.TestCase):
     """Test the CollOfListOfWfErr class."""
 
     def setUp(self):
 
-        self.collOfListOfWfErr = MTAOS.CollOfListOfWfErr(10)
+        self.wavefront_collection = WavefrontCollection(10)
 
     def testGetNumOfData(self):
 
-        self.assertEqual(self.collOfListOfWfErr.getNumOfData(), 0)
+        self.assertEqual(self.wavefront_collection.getNumOfData(), 0)
 
     def testGetNumOfDataTaken(self):
 
-        self.assertEqual(self.collOfListOfWfErr.getNumOfDataTaken(), 0)
+        self.assertEqual(self.wavefront_collection.getNumOfDataTaken(), 0)
 
     def testAppend(self):
 
         listOfWfErr = self._prepareListOfWfErr()
-        self.collOfListOfWfErr.append(listOfWfErr)
+        self.wavefront_collection.append(listOfWfErr)
 
-        self.assertEqual(self.collOfListOfWfErr.getNumOfData(), 1)
+        self.assertEqual(self.wavefront_collection.getNumOfData(), 1)
 
     def _prepareListOfWfErr(self):
 
@@ -69,49 +69,52 @@ class TestCollOfListOfWfErr(unittest.TestCase):
 
     def testPopWithoutData(self):
 
-        self.assertEqual(self.collOfListOfWfErr.pop(), [])
+        self.assertEqual(self.wavefront_collection.pop(), [])
 
     def testPopWithData(self):
 
-        self.assertEqual(self.collOfListOfWfErr.getNumOfDataTaken(), 0)
+        self.assertEqual(self.wavefront_collection.getNumOfDataTaken(), 0)
 
         listOfWfErr = self._prepareListOfWfErr()
-        self.collOfListOfWfErr.append(listOfWfErr)
+        self.wavefront_collection.append(listOfWfErr)
 
-        listOfWfErrPop = self.collOfListOfWfErr.pop()
+        listOfWfErrPop = self.wavefront_collection.pop()
         self.assertEqual(len(listOfWfErrPop), 2)
         self.assertEqual(listOfWfErrPop[0].getSensorId(), 1)
         self.assertEqual(listOfWfErrPop[1].getSensorId(), 2)
 
-        self.assertEqual(self.collOfListOfWfErr.getNumOfDataTaken(), 1)
+        self.assertEqual(self.wavefront_collection.getNumOfDataTaken(), 1)
 
     def testClear(self):
 
         listOfWfErr = self._prepareListOfWfErr()
         for idx in range(3):
-            self.collOfListOfWfErr.append(listOfWfErr)
-        self.collOfListOfWfErr.pop()
+            self.wavefront_collection.append(listOfWfErr)
+        self.wavefront_collection.pop()
 
-        self.assertEqual(self.collOfListOfWfErr.getNumOfData(), 2)
-        self.assertEqual(self.collOfListOfWfErr.getNumOfDataTaken(), 1)
+        self.assertEqual(self.wavefront_collection.getNumOfData(), 2)
+        self.assertEqual(self.wavefront_collection.getNumOfDataTaken(), 1)
 
-        self.collOfListOfWfErr.clear()
+        self.wavefront_collection.clear()
 
-        self.assertEqual(self.collOfListOfWfErr.getNumOfData(), 0)
-        self.assertEqual(self.collOfListOfWfErr.getNumOfDataTaken(), 0)
+        self.assertEqual(self.wavefront_collection.getNumOfData(), 0)
+        self.assertEqual(self.wavefront_collection.getNumOfDataTaken(), 0)
 
     def testGetListOfWavefrontErrorAvgInTakenDataWithoutData(self):
 
         self.assertRaises(
-            RuntimeError, self.collOfListOfWfErr.getListOfWavefrontErrorAvgInTakenData
+            RuntimeError,
+            self.wavefront_collection.getListOfWavefrontErrorAvgInTakenData,
         )
 
     def testGetListOfWavefrontErrorAvgInTakenDataWithSglData(self):
 
         self._collectListOfWfErrForAvgTest()
-        self.collOfListOfWfErr.pop()
+        self.wavefront_collection.pop()
 
-        listOfWfErrAvg = self.collOfListOfWfErr.getListOfWavefrontErrorAvgInTakenData()
+        listOfWfErrAvg = (
+            self.wavefront_collection.getListOfWavefrontErrorAvgInTakenData()
+        )
 
         self.assertEqual(len(listOfWfErrAvg), 3)
         self.assertEqual(listOfWfErrAvg[0].getAnnularZernikePoly()[0], 1)
@@ -125,15 +128,17 @@ class TestCollOfListOfWfErr(unittest.TestCase):
     def _collectListOfWfErrForAvgTestSgl(self, listSensorId, listSensorZk):
 
         listOfWfErr = self._getListOfWfErr(listSensorId, listSensorZk)
-        self.collOfListOfWfErr.append(listOfWfErr)
+        self.wavefront_collection.append(listOfWfErr)
 
     def testGetListOfWavefrontErrorAvgInTakenDataWithMultiData(self):
 
         self._collectListOfWfErrForAvgTest()
         for idx in range(3):
-            self.collOfListOfWfErr.pop()
+            self.wavefront_collection.pop()
 
-        listOfWfErrAvg = self.collOfListOfWfErr.getListOfWavefrontErrorAvgInTakenData()
+        listOfWfErrAvg = (
+            self.wavefront_collection.getListOfWavefrontErrorAvgInTakenData()
+        )
 
         self.assertEqual(len(listOfWfErrAvg), 3)
         self.assertEqual(listOfWfErrAvg[0].getAnnularZernikePoly()[0], 2)
@@ -145,12 +150,14 @@ class TestCollOfListOfWfErr(unittest.TestCase):
 
         # There are only 2 sensor data here
         listOfWfErr = self._prepareListOfWfErr()
-        self.collOfListOfWfErr.append(listOfWfErr)
+        self.wavefront_collection.append(listOfWfErr)
 
         for idx in range(4):
-            self.collOfListOfWfErr.pop()
+            self.wavefront_collection.pop()
 
-        listOfWfErrAvg = self.collOfListOfWfErr.getListOfWavefrontErrorAvgInTakenData()
+        listOfWfErrAvg = (
+            self.wavefront_collection.getListOfWavefrontErrorAvgInTakenData()
+        )
 
         self.assertEqual(len(listOfWfErrAvg), 2)
         for idx in range(2):


### PR DESCRIPTION
* In Jenkinsfile, run pytest in the entire package instead of only the `tests/` folder, to capture pep8 and black violations in the entire repo.
* Refactor module names to the current telescope and site standards (lower_camel_case).
* Refactor additional parts of the code to be compliant with the current style guide.
* Implement new version of OFC.
* In CSC:
  * Refactor log-to-file interface.
  * In `addAberration` command:
    * Stop issuing corrections. Users need to send a `issueAberration` for the aberrations to be applied.
    * Implement `config` feature, to allow users to customize ofc behavior.
    * Add some unit tests for `addAberration` config feature.
* Update tests/Sconscript to allow running scons with licensed version of OpenSplice.