### PR TITLE
Tickets/dm 31279

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -2,6 +2,12 @@
 Version History
 ===============
 
+v0.7.2
+------
+
+* Support the setting of **xref**.
+* Add LSSTCam/calib to collections path in test Gen3 pipelines and fix the syntax of butler ``get()``.
+
 v0.7.1
 ------
 

--- a/python/lsst/ts/MTAOS/model.py
+++ b/python/lsst/ts/MTAOS/model.py
@@ -593,7 +593,7 @@ class Model:
                 "exposure": reference_id,
                 "detector": self.reference_detector,
             },
-            collections=self.collections,
+            collections=self.collections.split(","),
         )
 
         wep_configuration = config.copy()
@@ -834,6 +834,9 @@ class Model:
                             new_comp_dof_idx[comp_dof_idx_key] = np.array(
                                 new_comp_dof_idx[comp_dof_idx_key], dtype=bool
                             )
+
+                    elif key == "xref":
+                        self.ofc.ofc_data.xref = kwargs[key]
 
         except Exception:
             self.log.error(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -324,7 +324,7 @@ class TestAsyncModel(unittest.IsolatedAsyncioTestCase):
             data_path=data_path,
             ofc_data=ofc_data,
             run_name=run_name,
-            collections="LSSTCam/raw/all",
+            collections="LSSTCam/calib,LSSTCam/raw/all",
             pipeline_instrument=dict(comcam="lsst.obs.lsst.LsstCam"),
             data_instrument_name=dict(comcam="LSSTCam"),
             reference_detector=94,


### PR DESCRIPTION
* Support the setting of **xref**.
* Add LSSTCam/calib to collections path in test Gen3 pipelines and fix the syntax of butler `get()`.